### PR TITLE
Addition: Setup Danger checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Dangerfile
+++ b/Dangerfile
@@ -28,4 +28,4 @@ sourcefiles.each do |filename|
     end
   end
 end
-message("TODO check successful, #{added_todos} added TODO(s) have a linked issue") unless bad_todos || added_todos < 1
+message("TODO check successful, #{added_todos} added TODO(s) include(s) a linked issue") unless bad_todos || added_todos < 1

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,6 +12,17 @@ else
 end
 
 ## Checks that any TODOs on changed lines have a link to a github issue
+issue_regexp = Regexp.new(/https?:\/\/(?:www\.)?github\.com\/Mudlet\/Mudlet\/issues\/(\d+)/)
+sourcefile_regexp = Regexp.new(/.*\.(cpp|c|h|lua)$/)
 git.diff.each do |chunk|
-  message chunk.patch.lines
+  next unless chunk.path.match(sourcefile_regexp)
+  message("Source file #{chunk.path}")
+  additions = chunk.patch.lines.grep(/^\+/)
+  message(chunk.patch)
+  additions.each do |line|
+    if line.include?("TODO") then
+      issue_match = line.match(issue_regexp)
+      failure("TODO added in #{chunk.path} without a linked github issue") unless issue_match
+    end
+  end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -11,14 +11,19 @@ else
   message("PR title is proper, PR is of type `#{pr_type}`")
 end
 
-## Checks that any TODOs on changed lines have a link to a github issue
-issue_regexp = Regexp.new(/https?:\/\/(?:www\.)?github\.com\/Mudlet\/Mudlet\/issues\/(\d+)/)
+## Checks that any TODOs on added lines have a link to a github issue
+issue_regexp = Regexp.new(/https?:\/\/(?:www\.)?github\.com\/Mudlet\/Mudlet\/issues\/(\d+)/i)
 sourcefile_regexp = Regexp.new(/.*\.(cpp|c|h|lua)$/)
 sourcefiles = (git.modified_files + git.added_files).uniq.select { |file| file.match(sourcefile_regexp) }
+bad_todos = false
 sourcefiles.each do |filename|
   additions = git.diff_for_file(filename).patch.lines.grep(/^\+/)
   additions.each do |line|
     next unless line.include?("TODO")
-    failure("TODO included in additions to file `#{filename}` without an issue link") unless line.match(issue_regexp)
+    unless line.match(issue_regexp)
+      failure("TODO included in additions to file `#{filename}` without an issue link")
+      bad_todos = true
+    end
   end
 end
+message("TODO check successful, any added TODOs have a linked issue") unless bad_todos

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,6 @@
+# Automates some of the checks for PRs
+
+## Checks title formatting. This formatting is used for changelog and release note generation.
 title_regex = Regexp.new(/^\[?(fix|improvement|addition)\]?:/i)
 if github.pr_title.match(/^\[?WIP\]?\:/)
   failure("PR is still a WIP, do not merge") 
@@ -7,3 +10,8 @@ else
   pr_type = github.pr_title[title_regex,1]
   message("PR title is proper, PR is of type `#{pr_type}`")
 end
+
+## Checks that any TODOs on changed lines have a link to a github issue
+source_regex = Regexp.new(/src\/.*\.(cpp|h|lua)/i)
+active_source_files = (git.modified_files + git.added_files).uniq.select { |file| file.match(source_regex) }
+message("Active source files: #{active_source_files.to_s}")

--- a/Dangerfile
+++ b/Dangerfile
@@ -51,7 +51,8 @@ if total_todos > 0
     """
   end
   added_todos.each do |filename, issues|
-    todo_msg += "#{filename} adds issue(s): #{issues.join(' ')}\n"
+    issue_links = issues.map {|issue| "[#{issue}](https://github.com/Mudlet/Mudlet/issues/#{issue})" }
+    todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
   end
   markdown(todo_msg)
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -18,10 +18,10 @@ else
   pr_type = github.pr_title[title_regex,1]
   type_to_readable = { add: "Addition", fix: "Fix", improve: "Improvement" }
   display_type = type_to_readable[pr_type.downcase.to_sym]
-  message("PR title is proper, PR is of type `#{display_type}`")
+  message("PR title is proper (type: `#{display_type}`)")
 end
 
-## Gathers and displays TODOs, failing them if a source file contains a TODO with no githug issue
+## Gathers and displays TODOs, failing them if a source file contains a TODO with no github issue
 bad_todos = []
 added_todos = {}
 sourcefiles.each do |filename|

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,14 +16,16 @@ issue_regexp = Regexp.new(/https?:\/\/(?:www\.)?github\.com\/Mudlet\/Mudlet\/iss
 sourcefile_regexp = Regexp.new(/.*\.(cpp|c|h|lua)$/)
 sourcefiles = (git.modified_files + git.added_files).uniq.select { |file| file.match(sourcefile_regexp) }
 bad_todos = false
+added_todos = 0
 sourcefiles.each do |filename|
   additions = git.diff_for_file(filename).patch.lines.grep(/^\+/)
   additions.each do |line|
     next unless line.include?("TODO")
+    added_todos += 1
     unless line.match(issue_regexp)
       failure("TODO included in additions to file `#{filename}` without an issue link")
       bad_todos = true
     end
   end
 end
-message("TODO check successful, any added TODOs have a linked issue") unless bad_todos
+message("TODO check successful, #{added_todos} added TODO(s) have a linked issue") unless bad_todos || added_todos < 1

--- a/Dangerfile
+++ b/Dangerfile
@@ -13,5 +13,5 @@ end
 
 ## Checks that any TODOs on changed lines have a link to a github issue
 git.diff.each do |chunk|
-  message chunk.patch
+  message chunk.patch.lines
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -36,13 +36,13 @@ end
 bad_todos.uniq!
 total_todos = bad_todos.count + added_todos.count
 if total_todos > 0
-  todo_msg = "#{total_todos} file(s) with new TODO(s).\n"
+  todo_msg = "## #{total_todos} file(s) with new TODO(s).\n"
   added_todos.each do |filename, issues|
     issue_links = issues.map {|issue| "[#{issue}](https://github.com/Mudlet/Mudlet/issues/#{issue})" }
     todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
   end
   if bad_todos.size > 0
-    todo_msg += "#{bad_todos.size} file(s) with 1+ TODOs added without an issue link:\n"
+    todo_msg += "## #{bad_todos.size} file(s) with 1+ TODOs added without an issue link:\n"
     todo_msg += "* " + bad_todos.join("\n* ")
   end
   markdown(todo_msg)

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,6 +12,6 @@ else
 end
 
 ## Checks that any TODOs on changed lines have a link to a github issue
-source_regex = Regexp.new(/src\/.*\.(cpp|h|lua)/i)
-active_source_files = (git.modified_files + git.added_files).uniq.select { |file| file.match(source_regex) }
-message(active_source_files.join(" "))
+git.diff.each do |chunk|
+  message chunk.patch
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -14,15 +14,11 @@ end
 ## Checks that any TODOs on changed lines have a link to a github issue
 issue_regexp = Regexp.new(/https?:\/\/(?:www\.)?github\.com\/Mudlet\/Mudlet\/issues\/(\d+)/)
 sourcefile_regexp = Regexp.new(/.*\.(cpp|c|h|lua)$/)
-git.diff.each do |chunk|
-  next unless chunk.path.match(sourcefile_regexp)
-  message("Source file #{chunk.path}")
-  additions = chunk.patch.lines.grep(/^\+/)
-  message(chunk.patch)
+sourcefiles = (git.modified_files + git.added_files).uniq.select { |file| file.match(sourcefile_regexp) }
+sourcefiles.each do |filename|
+  additions = git.diff_for_file(filename).patch.lines.grep(/^\+/)
   additions.each do |line|
-    if line.include?("TODO") then
-      issue_match = line.match(issue_regexp)
-      failure("TODO added in #{chunk.path} without a linked github issue") unless issue_match
-    end
+    next unless line.include?("TODO")
+    failure("TODO included in additions to file #{filename} without an issue link") unless line.match(issue_regexp)
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -37,13 +37,13 @@ bad_todos.uniq!
 total_todos = bad_todos.count + added_todos.count
 if total_todos > 0
   todo_msg = "#{total_todos} file(s) with new TODO(s).\n"
-  if bad_todos.size > 0
-    todo_msg += "There is at least one TODO added without an issue link:\n"
-    todo_msg += "  " + bad_todos.join("\n  ")
-  end
   added_todos.each do |filename, issues|
     issue_links = issues.map {|issue| "[#{issue}](https://github.com/Mudlet/Mudlet/issues/#{issue})" }
     todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
+  end
+  if bad_todos.size > 0
+    todo_msg += "#{bad_todos.size} file(s) with 1+ TODOs added without an issue link:\n"
+    todo_msg += "* " + bad_todos.join("\n* ")
   end
   markdown(todo_msg)
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -42,7 +42,8 @@ if total_todos > 0
     todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
   end
   if bad_todos.size > 0
-    todo_msg += "## #{bad_todos.size} file(s) with 1+ TODOs added without an issue link:\n"
+    todo_msg += "## Bad TODOs\n\n"
+    todo_msg += "There are #{bad_todos.size} files with bad TODOs in them.\n\n"
     todo_msg += "* " + bad_todos.join("\n* ")
   end
   markdown(todo_msg)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,8 +1,9 @@
+title_regex = /^\[(fix|improvement|addition)\]:/i
 if github.pr_title.match(/^\[?WIP\]?\:/)
   failure("PR is still a WIP, do not merge") 
-elsif github.pr_title.match(/^\[(fix|improvement|addition)\]:/i)
+elsif github.pr_title.match(title_regex)
   failure("PR title must start with `Fix:`, `Improvement:`, or `Addition:` in order to be merged")
 else
-  pr_type = github.pr_title[/^\[(fix|improvement|addition)\]:/i,1]
+  pr_type = github.pr_title[title_regex,1]
   message("PR title is proper, PR is of type `#{pr_type}`")
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -42,14 +42,13 @@ bad_todos.uniq!
 total_todos = bad_todos.count + added_todos.count
 if total_todos > 0
   todo_msg = "## #{total_todos} file(s) with new TODO(s).\n\n"
-  todo_msg += "## #{added_todos.count} TODOs with links\n\n" if added_todos.count > 0
+  todo_msg += "## #{added_todos.count} files with links\n\n" if added_todos.count > 0
   added_todos.each do |filename, issues|
     issue_links = issues.map {|issue| "[#{issue}](https://github.com/#{PROJ}/#{REPO}/issues/#{issue})" }
     todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
   end
   if bad_todos.size > 0
-    todo_msg += "## Bad TODOs\n\n"
-    todo_msg += "There are #{bad_todos.size} files with bad TODOs in them.\n\n"
+    todo_msg += "## #{bad_todos.size} files with bad TODOs added\n\n"
     todo_msg += "* " + bad_todos.join("\n* ")
   end
   markdown(todo_msg)

--- a/Dangerfile
+++ b/Dangerfile
@@ -42,13 +42,13 @@ bad_todos.uniq!
 total_todos = bad_todos.count + added_todos.count
 if total_todos > 0
   todo_msg = "## #{total_todos} file(s) with new TODO(s).\n\n"
-  todo_msg += "## #{added_todos.count} files with links\n\n" if added_todos.count > 0
+  todo_msg += "### #{added_todos.count} files with links\n\n" if added_todos.count > 0
   added_todos.each do |filename, issues|
     issue_links = issues.map {|issue| "[#{issue}](https://github.com/#{PROJ}/#{REPO}/issues/#{issue})" }
     todo_msg += "#{filename} adds issue(s): #{issue_links.join(', ')}\n"
   end
   if bad_todos.size > 0
-    todo_msg += "## #{bad_todos.size} files with bad TODOs added\n\n"
+    todo_msg += "### #{bad_todos.size} files with bad TODOs added\n\n"
     todo_msg += "* " + bad_todos.join("\n* ")
   end
   markdown(todo_msg)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,7 +1,7 @@
-title_regex = /^\[(fix|improvement|addition)\]:/i
+title_regex = Regexp.new(/^\[?(fix|improvement|addition)\]?:/i)
 if github.pr_title.match(/^\[?WIP\]?\:/)
   failure("PR is still a WIP, do not merge") 
-elsif github.pr_title.match(title_regex)
+elsif not github.pr_title.match(title_regex)
   failure("PR title must start with `Fix:`, `Improvement:`, or `Addition:` in order to be merged")
 else
   pr_type = github.pr_title[title_regex,1]

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,6 +19,6 @@ sourcefiles.each do |filename|
   additions = git.diff_for_file(filename).patch.lines.grep(/^\+/)
   additions.each do |line|
     next unless line.include?("TODO")
-    failure("TODO included in additions to file #{filename} without an issue link") unless line.match(issue_regexp)
+    failure("TODO included in additions to file `#{filename}` without an issue link") unless line.match(issue_regexp)
   end
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -39,16 +39,7 @@ if total_todos > 0
   todo_msg = "#{total_todos} file(s) with new TODO(s).\n"
   if bad_todos.size > 0
     todo_msg += "There is at least one TODO added without an issue link:\n"
-    todo_msg += """
-    <details>
-      <summary>
-        Click to expand file list
-      </summary>
-      <p>
-      #{bad_todos.join("\n")}
-      </p>
-    </details>
-    """
+    todo_msg += "  " + bad_todos.join("\n  ")
   end
   added_todos.each do |filename, issues|
     issue_links = issues.map {|issue| "[#{issue}](https://github.com/Mudlet/Mudlet/issues/#{issue})" }
@@ -56,3 +47,4 @@ if total_todos > 0
   end
   markdown(todo_msg)
 end
+failure("TODO added without an issue link, see below for list of files.") if bad_todos.count > 0

--- a/Dangerfile
+++ b/Dangerfile
@@ -14,4 +14,4 @@ end
 ## Checks that any TODOs on changed lines have a link to a github issue
 source_regex = Regexp.new(/src\/.*\.(cpp|h|lua)/i)
 active_source_files = (git.modified_files + git.added_files).uniq.select { |file| file.match(source_regex) }
-message("Active source files: #{active_source_files.to_s}")
+message(active_source_files.join(" "))

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "danger"

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "danger"
+gem "pry"

--- a/src/something/header.h
+++ b/src/something/header.h
@@ -1,0 +1,1 @@
+// You can comment headers like this right? TODO: make this better

--- a/src/something/lua/another.lua
+++ b/src/something/lua/another.lua
@@ -1,0 +1,1 @@
+-- TODO: I should probably include an issue here

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,1 +1,1 @@
--- TODO: some stuff https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
+-- TODO: some stuff no link on the same line

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,1 +1,1 @@
--- TODO: some stuff
+-- TODO: some stuff https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,2 +1,2 @@
 -- TODO: https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
--- now this TODO will not hold up the PR
+-- now this item will not hold up the PR

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,2 +1,2 @@
-
+-- TODO: https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
 -- now this item will not hold up the PR

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,1 +1,2 @@
--- TODO: some stuff no link on the same line
+-- TODO: https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
+-- now this TODO will not hold up the PR

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,0 +1,1 @@
+-- TODO: some stuff

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,2 +1,2 @@
--- TODO: https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
+
 -- now this item will not hold up the PR

--- a/src/something/lua/source.lua
+++ b/src/something/lua/source.lua
@@ -1,2 +1,4 @@
 -- TODO: https://github.com/Mudlet/Mudlet/issues/4515#issuecomment-932980619
 -- now this item will not hold up the PR
+
+-- TODO: https://github.com/Mudlet/Mudlet/issues/5450

--- a/src/something/test.cpp
+++ b/src/something/test.cpp
@@ -1,0 +1,2 @@
+// TODO: https://github.com/Mudlet/Mudlet/issues/5476
+// we should not wipe the thing!


### PR DESCRIPTION
Mock up to show Danger automation of PR checks, including 2 of the items discussed in today's meeting already implemented.
Anything marked as a 'failure' causes the danger/danger-pr check to fail until they are fixed.

This has in my experience worked out much better than relying on self discipline.

PR Title is good, no new TODOs added:
![proper-title-no-new-TODOs](https://user-images.githubusercontent.com/3660/135773301-37fa6068-0fdf-4ec3-9950-438bea562a0f.png)

PR Title is improper, and there's a bad todo:
![improper-title-bad-todo](https://user-images.githubusercontent.com/3660/135773309-edd41148-9dba-4909-b1ae-5bbcea3f9273.png)

PR title is good, TODO added but has an issue link:
![proper-title-good-todo-added](https://user-images.githubusercontent.com/3660/135773334-cdb815f5-a76a-4585-be16-12e011919247.png)

WIP title, bad TODO:
![wip-bad-todo-added](https://user-images.githubusercontent.com/3660/135773344-15f18486-a3a1-4a8c-9d97-617954b36f5c.png)


